### PR TITLE
remove clerezza library in favor of jena

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,16 +39,13 @@
     <!-- dependencies -->
     <camel.version>2.15.1</camel.version>
     <camel.version.range>[2.15.0,3)</camel.version.range>
-    <clerezza.ext.jena.version>2.11.1_1</clerezza.ext.jena.version>
-    <clerezza.rdf.jena.serializer.version>0.11</clerezza.rdf.jena.serializer.version>
-    <clerezza.rdf.jena.parser.version>0.12</clerezza.rdf.jena.parser.version>
-    <clerezza.rdf.core.version>0.14</clerezza.rdf.core.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang3.version>3.3.2</commons.lang3.version>
     <commons.logging.version>1.1.3</commons.logging.version>
     <grizzly.version>2.3.18</grizzly.version>
     <guava.version>18.0</guava.version>
     <httpclient.version>4.3.6</httpclient.version>
+    <jena.version>2.13.0</jena.version>
     <jena.fuseki.version>1.1.1</jena.fuseki.version>
     <jersey.version>2.15</jersey.version>
     <mockito.version>1.10.8</mockito.version>
@@ -56,15 +53,12 @@
     <solr.version>4.10.2</solr.version>
     <spring.version>4.1.4.RELEASE</spring.version>
     <!-- osgi bundle transitive dependencies (for karaf provisioning) -->
-    <clerezza.utils.version>0.2</clerezza.utils.version>
-    <clerezza.ext.icu.version>0.6</clerezza.ext.icu.version>
-    <clerezza.ext.jena.iri.version>1.0.1_1</clerezza.ext.jena.iri.version>
-    <clerezza.rdf.jena.facade.version>0.14</clerezza.rdf.jena.facade.version>
-    <clerezza.rdf.jena.commons.version>0.7</clerezza.rdf.jena.commons.version>
     <commons.codec.version>1.9</commons.codec.version>
-    <felix.osgi.version>1.4.0</felix.osgi.version>
+    <commons.csv.version>1.1</commons.csv.version>
     <httpcore.version>4.3.3</httpcore.version>
-    <wymiwyg.version>0.7.6</wymiwyg.version>
+    <thrift.version>0.9.2</thrift.version>
+    <jackson2.version>2.3.0</jackson2.version>
+    <jsonld.version>0.5.1</jsonld.version>
     <!-- plugins -->
     <build.helper.plugin.version>1.9.1</build.helper.plugin.version>
     <bundle.plugin.version>2.5.3</bundle.plugin.version>
@@ -160,30 +154,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.clerezza</groupId>
-      <artifactId>rdf.core</artifactId>
-      <version>${clerezza.rdf.core.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.clerezza</groupId>
-      <artifactId>rdf.jena.parser</artifactId>
-      <version>${clerezza.rdf.jena.parser.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.clerezza</groupId>
-      <artifactId>rdf.jena.serializer</artifactId>
-      <version>${clerezza.rdf.jena.serializer.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.clerezza.ext</groupId>
-      <artifactId>org.apache.jena.jena-core</artifactId>
-      <version>${clerezza.ext.jena.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons.lang3.version}</version>
@@ -199,6 +169,7 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${commons.io.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -211,6 +182,12 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
       <version>${spring.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-core</artifactId>
+      <version>${jena.version}</version>
     </dependency>
 
     <!-- logging -->
@@ -274,6 +251,13 @@
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-fuseki</artifactId>
       <version>${jena.fuseki.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-arq</artifactId>
+      <version>${jena.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/org/fcrepo/camel/processor/ProcessorUtils.java
+++ b/src/main/java/org/fcrepo/camel/processor/ProcessorUtils.java
@@ -15,10 +15,10 @@
  */
 package org.fcrepo.camel.processor;
 
+import static com.hp.hpl.jena.util.URIref.encode;
 import java.io.IOException;
 
 import org.apache.camel.Message;
-import org.apache.clerezza.rdf.core.UriRef;
 import org.apache.commons.lang3.StringUtils;
 import org.fcrepo.camel.FcrepoHeaders;
 import org.fcrepo.camel.JmsHeaders;
@@ -43,6 +43,25 @@ public final class ProcessorUtils {
             trimmed = trimmed.substring(0, trimmed.length() - 1);
         }
         return trimmed;
+    }
+
+    /**
+     * Extract a language string suitable for Jena from a MimeType value
+     * @param contentType a MIMEType string
+     * @return a Jena-compatible language string
+     */
+    public static String langFromMimeType(final String contentType) {
+        if (contentType.equals("application/n-triples")) {
+            return "N-TRIPLE";
+        } else if (contentType.equals("text/turtle")) {
+            return "TURTLE";
+        } else if (contentType.equals("application/rdf+xml")) {
+            return "RDF/XML";
+        } else if (contentType.equals("text/rdf+n3") || contentType.equals("text/n3")) {
+            return "N3";
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -82,11 +101,11 @@ public final class ProcessorUtils {
 
         if (!StringUtils.isBlank(namedGraph)) {
             stmt.append("GRAPH ");
-            stmt.append(new UriRef(namedGraph));
+            stmt.append("<" + encode(namedGraph) + ">");
             stmt.append(" { ");
         }
 
-        stmt.append(new UriRef(subject));
+        stmt.append("<" + encode(subject) + ">");
         stmt.append(" ?p ?o ");
 
         if (!StringUtils.isBlank(namedGraph)) {
@@ -108,9 +127,9 @@ public final class ProcessorUtils {
         final StringBuilder query = new StringBuilder("INSERT DATA { ");
 
         if (!StringUtils.isBlank(namedGraph)) {
-            query.append("GRAPH ");
-            query.append(new UriRef(namedGraph));
-            query.append(" { ");
+            query.append("GRAPH <");
+            query.append(encode(namedGraph));
+            query.append("> { ");
         }
 
         query.append(serializedGraph);

--- a/src/main/java/org/fcrepo/camel/processor/SparqlDescribeProcessor.java
+++ b/src/main/java/org/fcrepo/camel/processor/SparqlDescribeProcessor.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
-import org.apache.clerezza.rdf.core.UriRef;
 
 /**
  * Represents a Processor class that formulates a Sparql DESCRIBE query
@@ -45,9 +44,9 @@ public class SparqlDescribeProcessor implements Processor {
     public void process(final Exchange exchange) throws IOException {
 
         final Message in = exchange.getIn();
-        final UriRef subject = new UriRef(ProcessorUtils.getSubjectUri(in));
+        final String subject = ProcessorUtils.getSubjectUri(in);
 
-        exchange.getIn().setBody("query=DESCRIBE " + subject);
+        exchange.getIn().setBody("query=DESCRIBE <" + subject + ">");
         exchange.getIn().setHeader(Exchange.HTTP_METHOD, "POST");
         exchange.getIn().setHeader(Exchange.ACCEPT_CONTENT_TYPE, "application/rdf+xml");
         exchange.getIn().setHeader(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");

--- a/src/main/java/org/fcrepo/camel/processor/SparqlInsertProcessor.java
+++ b/src/main/java/org/fcrepo/camel/processor/SparqlInsertProcessor.java
@@ -15,20 +15,18 @@
  */
 package org.fcrepo.camel.processor;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.camel.processor.ProcessorUtils.insertData;
+import static org.fcrepo.camel.processor.ProcessorUtils.langFromMimeType;
 
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
+
+import com.hp.hpl.jena.rdf.model.Model;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
-import org.apache.clerezza.rdf.core.MGraph;
-import org.apache.clerezza.rdf.core.UriRef;
-import org.apache.clerezza.rdf.core.impl.SimpleMGraph;
-import org.apache.clerezza.rdf.core.serializedform.ParsingProvider;
-import org.apache.clerezza.rdf.core.serializedform.SerializingProvider;
-import org.apache.clerezza.rdf.jena.parser.JenaParserProvider;
-import org.apache.clerezza.rdf.jena.serializer.JenaSerializerProvider;
 import org.fcrepo.camel.FcrepoHeaders;
 
 /**
@@ -47,23 +45,17 @@ public class SparqlInsertProcessor implements Processor {
     public void process(final Exchange exchange) throws IOException {
 
         final Message in = exchange.getIn();
-        final ParsingProvider parser = new JenaParserProvider();
-        final SerializingProvider serializer = new JenaSerializerProvider();
-        final MGraph graph = new SimpleMGraph();
-        final String contentType = in.getHeader(Exchange.CONTENT_TYPE, String.class);
-        final String namedGraph = in.getHeader(FcrepoHeaders.FCREPO_NAMED_GRAPH, String.class);
+
         final ByteArrayOutputStream serializedGraph = new ByteArrayOutputStream();
         final String subject = ProcessorUtils.getSubjectUri(in);
+        final String namedGraph = in.getHeader(FcrepoHeaders.FCREPO_NAMED_GRAPH, String.class);
+        final Model model = createDefaultModel().read(in.getBody(InputStream.class), subject,
+                langFromMimeType(in.getHeader(Exchange.CONTENT_TYPE, String.class)));
 
-        /* the text/rdf+nt mimetype will be removed in the next version of clerezza
-         * at which point they will be using application/n-triples. Once that happens,
-         * this ternary expression can be removed. */
-        parser.parse(graph, in.getBody(InputStream.class),
-                "application/n-triples".equals(contentType) ? "text/rdf+nt" : contentType, new UriRef(subject));
-        serializer.serialize(serializedGraph, graph.getGraph(), "text/rdf+nt");
+        model.write(serializedGraph, "N-TRIPLE");
 
         final StringBuilder query = new StringBuilder("update=");
-        query.append(ProcessorUtils.insertData(serializedGraph.toString("UTF-8"), namedGraph));
+        query.append(insertData(serializedGraph.toString("UTF-8"), namedGraph));
 
         exchange.getIn().setBody(query.toString());
         exchange.getIn().setHeader(Exchange.HTTP_METHOD, "POST");

--- a/src/main/resources/features.xml
+++ b/src/main/resources/features.xml
@@ -2,24 +2,22 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0" name="fcrepo-camel-${project.version}">
   <feature name="fcrepo-camel" version="${project.version}" resolver="(obr)" start-level="50">
     <details>Installs the fcrepo-camel component</details>
-    <bundle>mvn:org.fcrepo.camel/fcrepo-camel/${project.version}</bundle>
-    <bundle dependency="true">mvn:commons-codec/commons-codec/${commons.codec.version}</bundle>
-    <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza.ext/com.ibm.icu/${clerezza.ext.icu.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza.ext/org.apache.jena.jena-core/${clerezza.ext.jena.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza.ext/org.apache.jena.jena-iri/${clerezza.ext.jena.iri.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza.ext/org.apache.jena.jena-arq/${clerezza.ext.jena.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza/rdf.core/${clerezza.rdf.core.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza/rdf.jena.serializer/${clerezza.rdf.jena.serializer.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza/rdf.jena.parser/${clerezza.rdf.jena.parser.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza/rdf.jena.facade/${clerezza.rdf.jena.facade.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza/rdf.jena.commons/${clerezza.rdf.jena.commons.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza/utils/${clerezza.utils.version}</bundle>
+
+    <feature version="${camel.version.range}">camel</feature>
+
+    <bundle dependency="true">mvn:org.apache.commons/commons-codec/${commons.codec.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.commons/commons-csv/${commons.csv.version}</bundle>
     <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang3.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.felix/org.osgi.compendium/${felix.osgi.version}</bundle>
     <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient.version}</bundle>
     <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore.version}</bundle>
-    <bundle dependency="true">mvn:org.wymiwyg/wymiwyg-commons-core/${wymiwyg.version}</bundle>
-    <feature version="${camel.version.range}">camel</feature>
+    <bundle dependency="true">mvn:org.apache.jena/jena-osgi/${jena.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.thrift/libthrift/${thrift.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2.version}</bundle>
+    <bundle dependency="true">mvn:com.github.jsonld-java/jsonld-java/${jsonld.version}</bundle>
+    <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
+
+    <bundle>mvn:org.fcrepo.camel/fcrepo-camel/${project.version}</bundle>
   </feature>
 </features>


### PR DESCRIPTION
Follow-on ticket to https://jira.duraspace.org/browse/FCREPO-1667

A newly introduced Jena class was causing conflicts with the (older) wrapped bundles from clerezza. This PR simply removes our use of clerezza and replaces it with an OSGi-friendly version of jena.