### PR TITLE
Specify a version range for fcrepo-java-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
     <spring.version>4.2.5.RELEASE</spring.version>
     <fcrepo.version>4.6.0</fcrepo.version>
     <fcrepo-java-client.version>0.1.3</fcrepo-java-client.version>
+    <fcrepo-java-client.version.range>[${fcrepo-java-client.version},0.2)</fcrepo-java-client.version.range>
+
     <!-- osgi bundle transitive dependencies (for karaf provisioning) -->
     <commons.codec.version>1.9</commons.codec.version>
     <commons.csv.version>1.1</commons.csv.version>
@@ -62,7 +64,7 @@
     <paxexam.plugin.version>1.2.4</paxexam.plugin.version>
     <!-- osgi bundle configuration -->
     <osgi.export.packages>org.fcrepo.camel.*;version=${project.version}</osgi.export.packages>
-    <osgi.import.packages>*</osgi.import.packages>
+    <osgi.import.packages>org.fcrepo.client.*;version="${fcrepo-java-client.version.range}",*</osgi.import.packages>
   </properties>
 
   <scm>


### PR DESCRIPTION
fcrepo-java-client 0.1.3 is not compatible with 0.2.x.  Make sure that
Import-Packages imports only from 0.1.x.  The default range is [0.1.3, 1) based
on semantic versioning conventions.  What's really desired is [0.1.3, 0.2).  