### PR TITLE
Update to fcrepo-java-client 0.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,7 @@
     <slf4j.version>1.7.20</slf4j.version>
     <spring.version>4.2.5.RELEASE</spring.version>
     <fcrepo.version>4.6.0</fcrepo.version>
-    <fcrepo-java-client.version>0.1.3</fcrepo-java-client.version>
-    <fcrepo-java-client.version.range>[${fcrepo-java-client.version},0.2)</fcrepo-java-client.version.range>
+    <fcrepo-java-client.version>0.2.1</fcrepo-java-client.version>
 
     <!-- osgi bundle transitive dependencies (for karaf provisioning) -->
     <commons.codec.version>1.9</commons.codec.version>
@@ -65,7 +64,7 @@
     <paxexam.plugin.version>1.2.4</paxexam.plugin.version>
     <!-- osgi bundle configuration -->
     <osgi.export.packages>org.fcrepo.camel.*;version=${project.version}</osgi.export.packages>
-    <osgi.import.packages>org.fcrepo.client.*;version="${fcrepo-java-client.version.range}",*</osgi.import.packages>
+    <osgi.import.packages>*</osgi.import.packages>
   </properties>
 
   <scm>

--- a/src/main/java/org/fcrepo/camel/FcrepoPrefer.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoPrefer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel;
+
+import static java.util.Arrays.stream;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A class representing the value of an HTTP Prefer header
+ *
+ * @author Aaron Coburn
+ */
+public class FcrepoPrefer {
+
+    private static final String LINK_DELIM = ";\\s*";
+
+    private static final String OMIT = "omit";
+
+    private static final String INCLUDE = "include";
+
+    private String returnType = null;
+
+    private List<URI> omit;
+
+    private List<URI> include;
+
+    /**
+     * Create a representation of a Prefer header.
+     *
+     * @param prefer the value for a Prefer header
+     */
+    public FcrepoPrefer(final String prefer) {
+        parse(prefer);
+    }
+
+    /**
+     * Whether a minimal representation has been requested
+     * @return whether this is a minimal request
+     */
+    public boolean isMinimal() {
+        return returnType != null && returnType.equals("minimal");
+    }
+
+    /**
+     * Whether a non-minimal representation has been requested
+     * @return whether this is a non-minimal request
+     */
+    public boolean isRepresentation() {
+        return returnType != null && returnType.equals("representation");
+    }
+
+    /**
+     * Retrieve the omit portion of a Prefer header
+     *
+     * @return the omit portion of a Prefer header
+     */
+    public List<URI> getOmit() {
+        return omit;
+    }
+
+    /**
+     * Retrieve the include portion of the prefer header
+     *
+     * @return the include portion of a Prefer header
+     */
+    public List<URI> getInclude() {
+        return include;
+    }
+
+    /**
+     * Parse the value of a prefer header
+     */
+    private void parse(final String prefer) {
+        if (prefer != null) {
+            final Map<String, String> data = new HashMap<>();
+
+            for (final String section : prefer.split(";\\s*")) {
+                final String[] parts = section.split("=");
+                if (parts.length == 2) {
+                    final String value;
+                    if (parts[1].startsWith("\"") && parts[1].endsWith("\"")) {
+                        value = parts[1].substring(1, parts[1].length() - 1);
+                    } else {
+                        value = parts[1];
+                    }
+                    data.put(parts[0], value);
+                }
+            }
+            this.returnType = data.get("return");
+            this.include = getUris(data.get("include"));
+            this.omit = getUris(data.get("omit"));
+        }
+    }
+
+    private List<URI> getUris(final String uris) {
+        if (uris != null) {
+            return stream(uris.split("\\s+")).filter(uri -> uri.length() > 0).map(URI::create).collect(toList());
+        }
+        return emptyList();
+    }
+}

--- a/src/main/java/org/fcrepo/camel/FcrepoPrefer.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoPrefer.java
@@ -20,11 +20,14 @@ package org.fcrepo.camel;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.slf4j.Logger;
 
 /**
  * A class representing the value of an HTTP Prefer header
@@ -33,7 +36,9 @@ import java.util.Map;
  */
 public class FcrepoPrefer {
 
-    private static final String LINK_DELIM = ";\\s*";
+    private static final Logger LOGGER = getLogger(FcrepoPrefer.class);
+
+    private static final String LINK_DELIM = "\\s*;\\s*";
 
     private static final String OMIT = "omit";
 
@@ -95,7 +100,7 @@ public class FcrepoPrefer {
         if (prefer != null) {
             final Map<String, String> data = new HashMap<>();
 
-            for (final String section : prefer.split(";\\s*")) {
+            for (final String section : prefer.split(LINK_DELIM)) {
                 final String[] parts = section.split("=");
                 if (parts.length == 2) {
                     final String value;
@@ -108,8 +113,10 @@ public class FcrepoPrefer {
                 }
             }
             this.returnType = data.get("return");
-            this.include = getUris(data.get("include"));
-            this.omit = getUris(data.get("omit"));
+            this.include = getUris(data.get(INCLUDE));
+            this.omit = getUris(data.get(OMIT));
+        } else {
+            LOGGER.warn("Could not parse a null Prefer value");
         }
     }
 

--- a/src/test/java/org/fcrepo/camel/FcrepoPreferTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoPreferTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel;
+
+import static java.net.URI.create;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * @author acoburn
+ */
+public class FcrepoPreferTest {
+
+    private final String embed = "http://fedora.info/definitions/v4/repository#EmbedResources";
+
+    private final String containment = "http://www.w3.org/ns/ldp#PreferContainment";
+
+    @Test
+    public void testPreferInclude() {
+        final FcrepoPrefer prefer = new FcrepoPrefer("return=representation; " +
+                "include=\"" + embed + "\"");
+        assertTrue(prefer.isRepresentation());
+        assertFalse(prefer.isMinimal());
+        assertEquals(singletonList(create(embed)), prefer.getInclude());
+        assertEquals(emptyList(), prefer.getOmit());
+    }
+
+    @Test
+    public void testPreferIncludeMultiple() {
+        final FcrepoPrefer prefer = new FcrepoPrefer("return=representation; " +
+                "include=\"" + embed + " " + containment + "\"");
+        assertTrue(prefer.isRepresentation());
+        assertFalse(prefer.isMinimal());
+        assertEquals(2, prefer.getInclude().size());
+        assertTrue(prefer.getInclude().contains(create(embed)));
+        assertTrue(prefer.getInclude().contains(create(containment)));
+        assertEquals(emptyList(), prefer.getOmit());
+    }
+
+    @Test
+    public void testPreferOmit() {
+        final FcrepoPrefer prefer = new FcrepoPrefer("return=representation; " +
+                "omit=\"" + embed + "\"");
+        assertTrue(prefer.isRepresentation());
+        assertFalse(prefer.isMinimal());
+        assertEquals(1, prefer.getOmit().size());
+        assertTrue(prefer.getOmit().contains(create(embed)));
+        assertEquals(emptyList(), prefer.getInclude());
+    }
+
+    @Test
+    public void testPreferOmitMultiple() {
+        final FcrepoPrefer prefer = new FcrepoPrefer("return=representation; " +
+                "omit=\"" + embed + " " + containment + "\"");
+        assertTrue(prefer.isRepresentation());
+        assertFalse(prefer.isMinimal());
+        assertEquals(2, prefer.getOmit().size());
+        assertTrue(prefer.getOmit().contains(create(embed)));
+        assertTrue(prefer.getOmit().contains(create(containment)));
+        assertEquals(emptyList(), prefer.getInclude());
+    }
+}


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2287

Most of the complexity and verbosity here relates to adding a class to model `Prefer` headers and updating the unit test code to account for the different interface of the `FcrepoClient`.