### PR TITLE
FCREPO-2987: Updates fcrepo-parent version to 5.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>fcrepo-camel</artifactId>
   <packaging>bundle</packaging>
 
-  <version>4.6.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
 
   <name>Fcrepo Camel Component</name>
   <description>Camel Component for interacting with a Fedora Repository</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>4.7.5</version>
+    <version>5.0.1</version>
   </parent>
 
   <groupId>org.fcrepo.camel</groupId>
@@ -37,18 +37,18 @@
     <github.global.server>github</github.global.server>
 
     <!-- dependencies -->
-    <activemq.version>5.14.0</activemq.version>
-    <camel.version>2.18.2</camel.version>
-    <camel.version.range>[2.18,3)</camel.version.range>
+    <activemq.version>5.15.5</activemq.version>
+    <camel.version>2.19.5</camel.version>
+    <camel.version.range>[2.19.5,3)</camel.version.range>
     <commons.io.version>2.4</commons.io.version>
-    <commons.lang3.version>3.7</commons.lang3.version>
+    <commons.lang3.version>3.8.1</commons.lang3.version>
     <httpclient.version>4.5.2</httpclient.version>
-    <karaf.version>4.0.6</karaf.version>
+    <karaf.version>4.2.2</karaf.version>
     <jena.version>3.1.1</jena.version>
     <mockito.version>1.10.8</mockito.version>
-    <pax-exam.version>4.8.0</pax-exam.version>
+    <pax-exam.version>4.13.1</pax-exam.version>
     <slf4j.version>1.7.20</slf4j.version>
-    <spring.version>4.2.5.RELEASE</spring.version>
+    <spring.version>4.3.22.RELEASE</spring.version>
     <fcrepo.version>5.0.1</fcrepo.version>
     <fcrepo-java-client.version>0.4.0</fcrepo-java-client.version>
 
@@ -206,6 +206,12 @@
       <artifactId>camel-test-karaf</artifactId>
       <version>${camel.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.ops4j.pax.exam</groupId>
+          <artifactId>pax-exam</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -339,10 +345,16 @@
             <fcrepo.dynamic.stomp.port>${fcrepo.dynamic.stomp.port}</fcrepo.dynamic.stomp.port>
             <commons.codec.version>${commons.codec.version}</commons.codec.version>
             <commons.csv.version>${commons.csv.version}</commons.csv.version>
+            <commons.lang3.version>${commons.lang3.version}</commons.lang3.version>
+            <camelKarafFeatureVersion>${camel.version}</camelKarafFeatureVersion>
             <dexx.version>${dexx-collection.version}</dexx.version>
             <httpclient.version>${httpclient.version}</httpclient.version>
             <httpcore.version>${httpcore.version}</httpcore.version>
             <jsonld.version>${jsonld.version}</jsonld.version>
+            <jena.osgi.version>${jena.version}</jena.osgi.version>
+            <jsonld.version>${jsonld.version}</jsonld.version>
+            <fcrepo.client.version>${fcrepo-java-client.version}</fcrepo.client.version>
+
             <thrift.version>${thrift.version}</thrift.version>
             <karaf.ssh.port>${karaf.ssh.port}</karaf.ssh.port>
             <karaf.rmiRegistry.port>${karaf.rmiRegistry.port}</karaf.rmiRegistry.port>

--- a/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
@@ -99,7 +99,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      * @return a transaction template
      */
     public TransactionTemplate createTransactionTemplate() {
-        TransactionTemplate transactionTemplate;
+        final TransactionTemplate transactionTemplate;
 
         if (getTransactionManager() != null) {
             transactionTemplate = new TransactionTemplate(getTransactionManager());

--- a/src/main/java/org/fcrepo/camel/FcrepoProducer.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoProducer.java
@@ -166,7 +166,7 @@ public class FcrepoProducer extends DefaultProducer {
 
         LOGGER.debug("Fcrepo Request [{}] with method [{}]", url, method);
 
-        FcrepoResponse response;
+        final FcrepoResponse response;
 
         switch (method) {
         case PATCH:

--- a/src/test/java/org/fcrepo/camel/integration/KarafIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/KarafIT.java
@@ -62,14 +62,20 @@ public class KarafIT extends AbstractFeatureTest {
         final String fcrepoCamelBundle = "file:" + getBaseDir() + "/target/" + artifactName + ".jar";
         final String commonsCodecVersion = cm.getProperty("commons.codec.version");
         final String commonsCsvVersion = cm.getProperty("commons.csv.version");
+        final String commonsLang3Version = cm.getProperty("commons.lang3.version");
         final String dexxVersion = cm.getProperty("dexx.version");
         final String httpclientVersion = cm.getProperty("httpclient.version");
         final String httpcoreVersion = cm.getProperty("httpcore.version");
         final String jsonldVersion = cm.getProperty("jsonld.version");
+        final String jenaOsgiVersion = cm.getProperty("jena.osgi.version");
+        final String javaClientVersion = cm.getProperty("fcrepo.client.version");
+
+
         final String thriftVersion = cm.getProperty("thrift.version");
         final String rmiRegistryPort = cm.getProperty("karaf.rmiRegistry.port");
         final String rmiServerPort = cm.getProperty("karaf.rmiServer.port");
         final String sshPort = cm.getProperty("karaf.ssh.port");
+
         return new Option[] {
             karafDistributionConfiguration()
                 .frameworkUrl(maven().groupId("org.apache.karaf").artifactId("apache-karaf")
@@ -89,13 +95,13 @@ public class KarafIT extends AbstractFeatureTest {
             mavenBundle().groupId("org.apache.camel").artifactId("camel-test-karaf").versionAsInProject(),
             mavenBundle().groupId("commons-codec").artifactId("commons-codec").version(commonsCodecVersion),
             mavenBundle().groupId("org.apache.commons").artifactId("commons-csv").version(commonsCsvVersion),
-            mavenBundle().groupId("org.apache.commons").artifactId("commons-lang3").versionAsInProject(),
-            mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpclient-osgi").versionAsInProject(),
-            mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpcore-osgi").versionAsInProject(),
-            mavenBundle().groupId("org.apache.jena").artifactId("jena-osgi").versionAsInProject(),
+            mavenBundle().groupId("org.apache.commons").artifactId("commons-lang3").version(commonsLang3Version),
+            mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpclient-osgi").version(httpclientVersion),
+            mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpcore-osgi").version(httpcoreVersion),
+            mavenBundle().groupId("org.apache.jena").artifactId("jena-osgi").version(jenaOsgiVersion),
             mavenBundle().groupId("com.github.jsonld-java").artifactId("jsonld-java").version(jsonldVersion),
             mavenBundle().groupId("org.apache.thrift").artifactId("libthrift").version(thriftVersion),
-            mavenBundle().groupId("org.fcrepo.client").artifactId("fcrepo-java-client").versionAsInProject(),
+            mavenBundle().groupId("org.fcrepo.client").artifactId("fcrepo-java-client").version(javaClientVersion),
             mavenBundle().groupId("com.github.andrewoma.dexx").artifactId("collection").version(dexxVersion),
             bundle(fcrepoCamelBundle).start()
        };


### PR DESCRIPTION
**Updates fcrepo-parent version to 5.0.1**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2987

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?

# What's new?
Updates the fcrepo-parent pom version to 5.0.1, camel to 2.19.5, karaf to 4.2.2, pax-exam to 4.13.1 other minor changes required to get the tests working again.

# How should this be tested?
mvn clean install

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? yes (updates)
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? yes 

# Interested parties
@birkland  @peichman-umd 