### PR TITLE
Revert plugin version changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>4.7.5</version>
+    <version>5.0.1</version>
   </parent>
 
   <groupId>org.fcrepo.camel</groupId>
   <artifactId>fcrepo-camel</artifactId>
   <packaging>bundle</packaging>
 
-  <version>4.6.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
 
   <name>Fcrepo Camel Component</name>
   <description>Camel Component for interacting with a Fedora Repository</description>
@@ -51,6 +51,8 @@
     <spring.version>4.2.5.RELEASE</spring.version>
     <fcrepo.version>5.0.1</fcrepo.version>
     <fcrepo-java-client.version>0.4.0</fcrepo-java-client.version>
+    <!-- jared's -->
+    <failsafe.plugin.version>2.18.1</failsafe.plugin.version>
 
     <!-- osgi bundle transitive dependencies (for karaf provisioning) -->
     <commons.codec.version>1.10</commons.codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>5.0.1</version>
+    <version>4.7.5</version>
   </parent>
 
   <groupId>org.fcrepo.camel</groupId>
   <artifactId>fcrepo-camel</artifactId>
   <packaging>bundle</packaging>
 
-  <version>5.0.0-SNAPSHOT</version>
+  <version>4.6.0-SNAPSHOT</version>
 
   <name>Fcrepo Camel Component</name>
   <description>Camel Component for interacting with a Fedora Repository</description>
@@ -37,18 +37,18 @@
     <github.global.server>github</github.global.server>
 
     <!-- dependencies -->
-    <activemq.version>5.15.5</activemq.version>
-    <camel.version>2.19.5</camel.version>
-    <camel.version.range>[2.19.5,3)</camel.version.range>
+    <activemq.version>5.14.0</activemq.version>
+    <camel.version>2.18.2</camel.version>
+    <camel.version.range>[2.18,3)</camel.version.range>
     <commons.io.version>2.4</commons.io.version>
-    <commons.lang3.version>3.8.1</commons.lang3.version>
+    <commons.lang3.version>3.7</commons.lang3.version>
     <httpclient.version>4.5.2</httpclient.version>
-    <karaf.version>4.2.2</karaf.version>
+    <karaf.version>4.0.6</karaf.version>
     <jena.version>3.1.1</jena.version>
     <mockito.version>1.10.8</mockito.version>
-    <pax-exam.version>4.13.1</pax-exam.version>
+    <pax-exam.version>4.8.0</pax-exam.version>
     <slf4j.version>1.7.20</slf4j.version>
-    <spring.version>4.3.22.RELEASE</spring.version>
+    <spring.version>4.2.5.RELEASE</spring.version>
     <fcrepo.version>5.0.1</fcrepo.version>
     <fcrepo-java-client.version>0.4.0</fcrepo-java-client.version>
 
@@ -206,12 +206,6 @@
       <artifactId>camel-test-karaf</artifactId>
       <version>${camel.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.ops4j.pax.exam</groupId>
-          <artifactId>pax-exam</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -345,16 +339,10 @@
             <fcrepo.dynamic.stomp.port>${fcrepo.dynamic.stomp.port}</fcrepo.dynamic.stomp.port>
             <commons.codec.version>${commons.codec.version}</commons.codec.version>
             <commons.csv.version>${commons.csv.version}</commons.csv.version>
-            <commons.lang3.version>${commons.lang3.version}</commons.lang3.version>
-            <camelKarafFeatureVersion>${camel.version}</camelKarafFeatureVersion>
             <dexx.version>${dexx-collection.version}</dexx.version>
             <httpclient.version>${httpclient.version}</httpclient.version>
             <httpcore.version>${httpcore.version}</httpcore.version>
             <jsonld.version>${jsonld.version}</jsonld.version>
-            <jena.osgi.version>${jena.version}</jena.osgi.version>
-            <jsonld.version>${jsonld.version}</jsonld.version>
-            <fcrepo.client.version>${fcrepo-java-client.version}</fcrepo.client.version>
-
             <thrift.version>${thrift.version}</thrift.version>
             <karaf.ssh.port>${karaf.ssh.port}</karaf.ssh.port>
             <karaf.rmiRegistry.port>${karaf.rmiRegistry.port}</karaf.rmiRegistry.port>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
 
     <!-- dependencies -->
     <activemq.version>5.14.0</activemq.version>
-    <camel.version>2.18.2</camel.version>
-    <camel.version.range>[2.18,3)</camel.version.range>
+    <camel.version>2.20.0</camel.version>
+    <camel.version.range>[2.20,3)</camel.version.range>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang3.version>3.7</commons.lang3.version>
     <httpclient.version>4.5.2</httpclient.version>

--- a/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
@@ -99,7 +99,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      * @return a transaction template
      */
     public TransactionTemplate createTransactionTemplate() {
-        final TransactionTemplate transactionTemplate;
+        TransactionTemplate transactionTemplate;
 
         if (getTransactionManager() != null) {
             transactionTemplate = new TransactionTemplate(getTransactionManager());

--- a/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
@@ -99,7 +99,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      * @return a transaction template
      */
     public TransactionTemplate createTransactionTemplate() {
-        TransactionTemplate transactionTemplate;
+        final TransactionTemplate transactionTemplate;
 
         if (getTransactionManager() != null) {
             transactionTemplate = new TransactionTemplate(getTransactionManager());
@@ -155,7 +155,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
 
     /**
      * configuration setter
-     * 
+     *
      * @param config The FcrepoConfiguration
      */
     public void setConfiguration(final FcrepoConfiguration config) {
@@ -222,7 +222,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
 
     /**
      * contentType setter
-     * 
+     *
      * @param type the mime-type used with Content-Type headers
      */
     @ManagedAttribute(description = "Content-Type: Header")
@@ -242,7 +242,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
 
     /**
      * authUsername setter
-     * 
+     *
      * @param username used for repository authentication
      */
     @ManagedAttribute(description = "Username for authentication")
@@ -262,7 +262,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
 
     /**
      * authPassword setter
-     * 
+     *
      * @param password used for repository authentication
      */
     @ManagedAttribute(description = "Password for authentication")
@@ -282,7 +282,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
 
     /**
      * authHost setter
-     * 
+     *
      * @param host realm used for repository authentication
      */
     @ManagedAttribute(description = "Hostname for authentication")

--- a/src/main/java/org/fcrepo/camel/FcrepoProducer.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoProducer.java
@@ -79,11 +79,11 @@ public class FcrepoProducer extends DefaultProducer {
 
     private static final String REPOSITORY = "http://fedora.info/definitions/v4/repository#";
 
-    private FcrepoEndpoint endpoint;
+    private final FcrepoEndpoint endpoint;
 
     private FcrepoClient fcrepoClient;
 
-    private TransactionTemplate transactionTemplate;
+    private final TransactionTemplate transactionTemplate;
 
     public static final Map<String, String> PREFER_PROPERTIES;
 
@@ -141,12 +141,13 @@ public class FcrepoProducer extends DefaultProducer {
     public void process(final Exchange exchange) throws FcrepoOperationFailedException {
         if (exchange.isTransacted()) {
             transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+                @Override
                 protected void doInTransactionWithoutResult(final TransactionStatus status) {
                     final DefaultTransactionStatus st = (DefaultTransactionStatus)status;
                     final FcrepoTransactionObject tx = (FcrepoTransactionObject)st.getTransaction();
                     try {
                         doRequest(exchange, tx.getSessionId());
-                    } catch (FcrepoOperationFailedException ex) {
+                    } catch (final FcrepoOperationFailedException ex) {
                         throw new TransactionSystemException(
                             "Error executing fcrepo request in transaction: ", ex);
                     }
@@ -166,7 +167,7 @@ public class FcrepoProducer extends DefaultProducer {
 
         LOGGER.debug("Fcrepo Request [{}] with method [{}]", url, method);
 
-        FcrepoResponse response;
+        final FcrepoResponse response;
 
         switch (method) {
         case PATCH:
@@ -367,7 +368,7 @@ public class FcrepoProducer extends DefaultProducer {
                 IOHelper.copyAndCloseInput(is, cos);
                 // When the InputStream is closed, the CachedOutputStream will be closed
                 return cos.newStreamCache();
-            } catch (IOException ex) {
+            } catch (final IOException ex) {
                 LOGGER.debug("Error extracting body from http request", ex);
                 return null;
             }

--- a/src/main/java/org/fcrepo/camel/FcrepoProducer.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoProducer.java
@@ -166,7 +166,7 @@ public class FcrepoProducer extends DefaultProducer {
 
         LOGGER.debug("Fcrepo Request [{}] with method [{}]", url, method);
 
-        final FcrepoResponse response;
+        FcrepoResponse response;
 
         switch (method) {
         case PATCH:

--- a/src/test/java/org/fcrepo/camel/integration/KarafIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/KarafIT.java
@@ -85,7 +85,9 @@ public class KarafIT extends AbstractFeatureTest {
             editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", sshPort),
             features(maven().groupId("org.apache.karaf.features").artifactId("standard")
                         .versionAsInProject().classifier("features").type("xml"), "scr"),
-            features(getCamelKarafFeatureUrl(), "camel-blueprint", "camel-spring", "camel-jackson"),
+            features(maven().groupId("org.apache.camel.karaf").artifactId("apache-camel")
+                    .type("xml").classifier("features").versionAsInProject(), "camel",
+                    "camel-blueprint", "camel-spring", "camel-jackson"),
             mavenBundle().groupId("org.apache.camel").artifactId("camel-test-karaf").versionAsInProject(),
             mavenBundle().groupId("commons-codec").artifactId("commons-codec").version(commonsCodecVersion),
             mavenBundle().groupId("org.apache.commons").artifactId("commons-csv").version(commonsCsvVersion),

--- a/src/test/java/org/fcrepo/camel/integration/KarafIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/KarafIT.java
@@ -62,20 +62,14 @@ public class KarafIT extends AbstractFeatureTest {
         final String fcrepoCamelBundle = "file:" + getBaseDir() + "/target/" + artifactName + ".jar";
         final String commonsCodecVersion = cm.getProperty("commons.codec.version");
         final String commonsCsvVersion = cm.getProperty("commons.csv.version");
-        final String commonsLang3Version = cm.getProperty("commons.lang3.version");
         final String dexxVersion = cm.getProperty("dexx.version");
         final String httpclientVersion = cm.getProperty("httpclient.version");
         final String httpcoreVersion = cm.getProperty("httpcore.version");
         final String jsonldVersion = cm.getProperty("jsonld.version");
-        final String jenaOsgiVersion = cm.getProperty("jena.osgi.version");
-        final String javaClientVersion = cm.getProperty("fcrepo.client.version");
-
-
         final String thriftVersion = cm.getProperty("thrift.version");
         final String rmiRegistryPort = cm.getProperty("karaf.rmiRegistry.port");
         final String rmiServerPort = cm.getProperty("karaf.rmiServer.port");
         final String sshPort = cm.getProperty("karaf.ssh.port");
-
         return new Option[] {
             karafDistributionConfiguration()
                 .frameworkUrl(maven().groupId("org.apache.karaf").artifactId("apache-karaf")
@@ -95,13 +89,13 @@ public class KarafIT extends AbstractFeatureTest {
             mavenBundle().groupId("org.apache.camel").artifactId("camel-test-karaf").versionAsInProject(),
             mavenBundle().groupId("commons-codec").artifactId("commons-codec").version(commonsCodecVersion),
             mavenBundle().groupId("org.apache.commons").artifactId("commons-csv").version(commonsCsvVersion),
-            mavenBundle().groupId("org.apache.commons").artifactId("commons-lang3").version(commonsLang3Version),
-            mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpclient-osgi").version(httpclientVersion),
-            mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpcore-osgi").version(httpcoreVersion),
-            mavenBundle().groupId("org.apache.jena").artifactId("jena-osgi").version(jenaOsgiVersion),
+            mavenBundle().groupId("org.apache.commons").artifactId("commons-lang3").versionAsInProject(),
+            mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpclient-osgi").versionAsInProject(),
+            mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpcore-osgi").versionAsInProject(),
+            mavenBundle().groupId("org.apache.jena").artifactId("jena-osgi").versionAsInProject(),
             mavenBundle().groupId("com.github.jsonld-java").artifactId("jsonld-java").version(jsonldVersion),
             mavenBundle().groupId("org.apache.thrift").artifactId("libthrift").version(thriftVersion),
-            mavenBundle().groupId("org.fcrepo.client").artifactId("fcrepo-java-client").version(javaClientVersion),
+            mavenBundle().groupId("org.fcrepo.client").artifactId("fcrepo-java-client").versionAsInProject(),
             mavenBundle().groupId("com.github.andrewoma.dexx").artifactId("collection").version(dexxVersion),
             bundle(fcrepoCamelBundle).start()
        };


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2787


# What does this Pull Request do?
I can not get master to compile on my Mac, but by reverting a bunch of these changes. Pulling in the new fcrepo-parent POM with its new versions **except** for the maven failsafe plugin

# What's new?
Reverts #149 and then re-applies the numbering change and sets the failsafe version to the old one.

A couple whitespace and final fixes that Eclipse did automatically.

These changes could be re-added, but I figured lets wait till we have a version for 5.0.0 out the door.

# How should this be tested?

Should build properly and should work with fcrepo-camel-toolbox in associated PR.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@birkland @peichman-umd @dbernstein or any other interested @fcrepo4/committers
