### PR TITLE
Reverts camel.version.range since it appears to cause downstream fail…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <!-- dependencies -->
     <activemq.version>5.14.0</activemq.version>
     <camel.version>2.20.4</camel.version>
-    <camel.version.range>[2.20.4,3)</camel.version.range>
+    <camel.version.range>[2.20,3)</camel.version.range>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang3.version>3.7</commons.lang3.version>
     <httpclient.version>4.5.2</httpclient.version>


### PR DESCRIPTION
…ures in fcreop-camel-toolbox.

# What does this Pull Request do?
In testing the newly minted fcrepo-camel-5.0.0 with fcrepo-camel-toolbox I discovered some failures which seem to be caused by the new feature range.  This PR simply reverts the camel.version.range.  When specifying a point release (such as 2.20.4) in the range, karaf is unable to resolve the dependency.

I made the change and tested the fix with fcrepo-camel-toolbox by running a full fcrepo-camel-toolbox build with the patched fcrepo-camel. 

# Interested parties
@awoods @whikloj 